### PR TITLE
Feature: Save Project Filter Setting in Local Storage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Github Clubhouse Story Linker",
   "manifest_version": 2,
-  "version": "1.3.1",
+  "version": "1.4",
   "description": "Allows you to easily search for Clubhouse stories from Github and link them to pull requests.",
   "icons": { "128": "images/icon-sm.png" },
   "browser_action": {


### PR DESCRIPTION
- updated minor version in manifest
- Saving project id of the selected project filter in local storage to save the filter setting between refreshes.
- Ignoring projects that are archived, not placing them in filter list.

When searching All projects (No filter), stories from archived projects will still appear in the search results. I'm not sure how to handle this, there doesn't appear to be any way to build a query string that is like "isnot:archived". I could iterate through the list of stories and toss the ones who's projects are archived, but this doesn't seem like a good solution.